### PR TITLE
Add step to free up space

### DIFF
--- a/.github/workflows/ghcr_release_docker.yml
+++ b/.github/workflows/ghcr_release_docker.yml
@@ -19,6 +19,9 @@ jobs:
       packages: write
 
     steps:
+      - name: "Free up space"
+        run: "sudo apt autoremove -y && sudo apt clean -y && sudo rm -rf /var/lib/apt/lists/* && sudo rm -rf /var/cache/apt/* && sudo rm -rf /tmp/* && sudo rm -rf /var/tmp"
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
       - name: "Checkout Repository"
         uses: actions/checkout@v4


### PR DESCRIPTION
The build step is failing because the runner does not have enough free space...

```
ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device
```

This might free up enough space.